### PR TITLE
Added a test case that seems to expose a bug

### DIFF
--- a/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
@@ -23,6 +23,14 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
       }
     }
 
+    it should "not grow when +(elem) operation is applied" in {
+      assertResult(bag.size) {
+        val eagerBag = bag
+        val newBag = eagerBag + 1
+        eagerBag.size
+      }
+    }
+
     it should "grow by m with +(elem->m) operation" in {
       assertResult(bag.size + 4) {
         (bag + (1 -> 4)).size


### PR DESCRIPTION
I added a test case that shows that mutable HashMap instances grow if the + operator is applied to them, although only the resulting HashMap should have the additional element. I guess this is a bug. I had to define a val eagerBag to avoid that bag is reevaluated each time it is called.

Disclaimer: I am not familiar with unit testing in Scala, maybe the test I added makes no sense.