### PR TITLE
2.11.x parity between string and int bag tests

### DIFF
--- a/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
@@ -55,6 +55,25 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
       }
     }
 
+    it should "have the same size when mapped" in {
+      assertResult(bag.size) {
+        (bag map identity).size
+      }
+      assertResult(bag.size) {
+        (bag map (s => -s)).size
+      }
+      assertResult(bag.size) {
+        (bag map (s => 28918265)).size
+      }
+    }
+
+    if (bag.nonEmpty) {
+      it should "implement reduce coherently" in {
+        assertResult(bag.toList.reduce(_ + _)) {
+          bag.reduce(_ + _)
+        }
+      }
+    }
 
     it should "implement [sum]" in {
       assertResult(bag.toList.sum) {
@@ -67,8 +86,6 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
         bag.product
       }
     }
-
-
   }
 
 

--- a/src/test/scala/scala/collection/scalatest/StringBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/StringBagBehaviours.scala
@@ -57,7 +57,7 @@ trait StringBagBehaviours extends BagBehaviours with Matchers {
 
     it should "have the same size when mapped" in {
       assertResult(bag.size) {
-        (bag map (s => s)).size
+        (bag map identity).size
       }
       assertResult(bag.size) {
         (bag map (s => s.toLowerCase)).size


### PR DESCRIPTION
This makes the tests in `IntBagBehaviours` a superset of those on '`StringBagBehaviours`. While `sum` and `product` are conceptually similar to 'reduce' for types supporting the `Numeric` typeclass, I thought it worth testing `reduce` in its own right, just as is done for string bags. (Indeed, the implementations are sufficiently distinct to warrant separate testing).

There is also a minor style change where I've used `identity` rather than `s => s` to make it more apparent that the mapping is an identity transformation in that case.