### PR TITLE
2.11.x bolster splitting tests

### DIFF
--- a/src/test/scala/scala/collection/scalatest/BagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/BagBehaviours.scala
@@ -110,7 +110,7 @@ trait BagBehaviours {
         }
       }
 
-      0 until bag.size foreach (validateSplitAt(_))
+      0 to bag.size foreach (validateSplitAt(_))
     }
 
     it should behave like bagBehaviour(bag)


### PR DESCRIPTION
This is a minor enhancement of the existing tests for splitting / take / drop.

It adds the corner case wherein the left hand of the split should be the entire bag, and the right hand should be empty (the corresponding corner case of an empty left hand and full right hand is already covered).