### PR TITLE
2.11.x fix mutable hash map bug

### DIFF
--- a/src/main/scala/scala/collection/mutable/HashBag.scala
+++ b/src/main/scala/scala/collection/mutable/HashBag.scala
@@ -38,7 +38,11 @@ final class HashBag[A] private[collection](contents: mutable.HashTable.Contents[
     this
   }
 
-  protected def updatedBucket(bucket: BagBucket): mutable.HashBag[A] = new mutable.HashBag[A](hashTableContents) updateBucket bucket
+  protected def updatedBucket(bucket: BagBucket): mutable.HashBag[A] = {
+    val result = empty
+    this.bucketsIterator foreach (result.addBucket(_))
+    result updateBucket bucket
+  }
 
   def bucketsIterator: Iterator[BagBucket] = entriesIterator.map(_.value)
 

--- a/src/test/scala/scala/collection/scalatest/BagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/BagBehaviours.scala
@@ -5,7 +5,7 @@ import org.scalatest._
 trait BagBehaviours {
   this: FlatSpec =>
 
-  def emptyBagBehaviour[A](bag: => scala.collection.Bag[A], bags: => Seq[scala.collection.Bag[A]]) {
+  def emptyBagBehaviour[A](bag: scala.collection.Bag[A], bags: Seq[scala.collection.Bag[A]]) {
     it should "be empty" in {
       assert(bag.isEmpty, s"bag = $bag")
     }
@@ -40,7 +40,7 @@ trait BagBehaviours {
 
   }
 
-  def nonEmptyBagBehaviour[A](bag: => scala.collection.Bag[A], bags: => Seq[scala.collection.Bag[A]]) {
+  def nonEmptyBagBehaviour[A](bag: scala.collection.Bag[A], bags: Seq[scala.collection.Bag[A]]) {
     it should "not be empty" in {
       assert(!bag.isEmpty, s"bag = $bag")
     }
@@ -118,7 +118,7 @@ trait BagBehaviours {
     it should behave like multisetBehaviour(bag, bags)
   }
 
-  private def multisetBehaviour[A](bag: => scala.collection.Bag[A], bags: => Seq[scala.collection.Bag[A]]) {
+  private def multisetBehaviour[A](bag: scala.collection.Bag[A], bags: Seq[scala.collection.Bag[A]]) {
 
     it should "implement [union] as a multiset union" in {
       for (bag2 <- bags) {
@@ -185,10 +185,9 @@ trait BagBehaviours {
         }
       }
     }
-
   }
 
-  private def bagBehaviour[A](bag: => scala.collection.Bag[A]) {
+  private def bagBehaviour[A](bag: scala.collection.Bag[A]) {
 
     it should "have non negative size" in {
       assert(bag.size >= 0, s"bag = $bag")

--- a/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
@@ -23,6 +23,14 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
       }
     }
 
+    it should "not grow when +(elem) operation is applied" in {
+      assertResult(bag.size) {
+        val eagerBag = bag
+        val newBag = eagerBag + 1
+        eagerBag.size
+      }
+    }
+
     it should "grow by m with +(elem->m) operation" in {
       assertResult(bag.size + 4) {
         (bag + (1 -> 4)).size

--- a/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/IntBagBehaviours.scala
@@ -6,7 +6,7 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
   this: FlatSpec =>
 
 
-  def intBagBehaviour(bag: => scala.collection.Bag[Int]) {
+  def intBagBehaviour(bag: scala.collection.Bag[Int]) {
 
     it should "grow by 1 with +(elem) operation" in {
       assertResult(bag.size + 1) {
@@ -20,14 +20,6 @@ trait IntBagBehaviours extends BagBehaviours with Matchers {
       assertResult(bag.size + 1) {
         val newBag = bag + 10
         newBag.size
-      }
-    }
-
-    it should "not grow when +(elem) operation is applied" in {
-      assertResult(bag.size) {
-        val eagerBag = bag
-        val newBag = eagerBag + 1
-        eagerBag.size
       }
     }
 

--- a/src/test/scala/scala/collection/scalatest/StringBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/StringBagBehaviours.scala
@@ -6,7 +6,7 @@ trait StringBagBehaviours extends BagBehaviours with Matchers {
   this: FlatSpec =>
 
 
-  def stringBagBehaviour(bag: => scala.collection.Bag[String]) {
+  def stringBagBehaviour(bag: scala.collection.Bag[String]) {
 
     it should "grow by 1 with +(elem) operation" in {
       assertResult(bag.size + 1) {


### PR DESCRIPTION
Fix for the unintended structure sharing between the receiver of the '+' operator on a mutable hash bag and the result.

The tests have been cut over to use strict evaluation when passing bags to the test suites - this exposed the structure sharing bug without writing an explicit bug reproduction test.

I removed the explicit test that demonstrated the bug simply because the structure sharing is not an anticipated property to test *for*, rather it was an accidental side effect, one of potentially an infinite number of possible incorrect side effects. However, it is not a deal-breaker if it is felt that this test should be retained, although I would mark it as a bug reproduction test in that case.

