### PR TITLE
add test for more mutation operations

### DIFF
--- a/src/test/scala/scala/collection/scalatest/mutable/MutableBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableBagBehaviours.scala
@@ -5,7 +5,7 @@ import org.scalatest._
 trait MutableBagBehaviours {
   this: FlatSpec =>
 
-  def mutableBagBehaviour[A](bag: => scala.collection.mutable.Bag[A], newElem: A) {
+  def nonEmptyMutableBagBehaviour[A](bag: => scala.collection.mutable.Bag[A], newElem: A) {
 
     it should "support removing single elements with -=" in {
       val b = bag
@@ -49,18 +49,45 @@ trait MutableBagBehaviours {
       }
     }
 
-    it should "be unchanged when removing elements that do not exist" in {
+    it should "support changing the multiplicity with setMultiplicity" in {
       val b = bag
       val elem = b.head
-      b.removeAll(elem)
+      b.setMultiplicity(elem, 3)
+      assert(b.multiplicity(elem) == 3)
+      b.setMultiplicity(elem, 5)
+      assert(b.multiplicity(elem) == 5)
+      b.setMultiplicity(elem, 0)
+      assert(b.multiplicity(elem) == 0)
+      assert(!b.contains(elem))
+    }
+
+    it should "support changing the multiplicity with update" in {
+      val b = bag
+      val elem = b.head
+      b.update(elem, 3)
+      assert(b.multiplicity(elem) == 3)
+      b.update(elem, 5)
+      assert(b.multiplicity(elem) == 5)
+      b.update(elem, 0)
+      assert(b.multiplicity(elem) == 0)
+      assert(!b.contains(elem))
+    }
+
+    it should behave like mutableBagBehaviour(bag, newElem)
+  }
+
+  def mutableBagBehaviour[A](bag: => scala.collection.mutable.Bag[A], newElem: A) {
+
+    it should "be unchanged when removing elements that do not exist" in {
+      val b = bag
       val expectedSize = b.size
-      b -= elem
+      b -= newElem
       assert(b.size == expectedSize)
-      b -= (elem, 1)
+      b -= (newElem, 1)
       assert(b.size == expectedSize)
-      b.remove(elem, 1)
+      b.remove(newElem, 1)
       assert(b.size == expectedSize)
-      b.removeAll(elem)
+      b.removeAll(newElem)
       assert(b.size == expectedSize)
     }
 
@@ -98,24 +125,6 @@ trait MutableBagBehaviours {
       assert(b.contains(newElem))
       assert(b.size == expectedSize)
       assert(b.multiplicity(newElem) == 3)
-    }
-
-    it should "support changing the multiplicity with setMultiplicity" in {
-      val b = bag
-      val elem = b.head
-      b.setMultiplicity(elem, 3)
-      assert(b.multiplicity(elem) == 3)
-      b.setMultiplicity(elem, 5)
-      assert(b.multiplicity(elem) == 5)
-    }
-
-    it should "support changing the multiplicity with update" in {
-      val b = bag
-      val elem = b.head
-      b.update(elem, 3)
-      assert(b.multiplicity(elem) == 3)
-      b.update(elem, 5)
-      assert(b.multiplicity(elem) == 5)
     }
   }
 }

--- a/src/test/scala/scala/collection/scalatest/mutable/MutableBagBehaviours.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableBagBehaviours.scala
@@ -5,7 +5,7 @@ import org.scalatest._
 trait MutableBagBehaviours {
   this: FlatSpec =>
 
-  def mutableBagBehaviour[A](bag: => scala.collection.mutable.Bag[A]) {
+  def mutableBagBehaviour[A](bag: => scala.collection.mutable.Bag[A], newElem: A) {
 
     it should "support removing single elements with -=" in {
       val b = bag
@@ -62,6 +62,60 @@ trait MutableBagBehaviours {
       assert(b.size == expectedSize)
       b.removeAll(elem)
       assert(b.size == expectedSize)
+    }
+
+    it should "support adding single elements with add" in {
+      val b = bag
+      b.add(newElem, 1)
+      val expectedSize = bag.size + 1
+      assert(b.contains(newElem))
+      assert(b.size == expectedSize)
+      assert(b.multiplicity(newElem) == 1)
+    }
+
+    it should "support adding multiple elements with add" in {
+      val b = bag
+      b.add(newElem, 3)
+      val expectedSize = bag.size + 3
+      assert(b.contains(newElem))
+      assert(b.size == expectedSize)
+      assert(b.multiplicity(newElem) == 3)
+    }
+
+    it should "support adding single elements with +=" in {
+      val b = bag
+      b += newElem
+      val expectedSize = bag.size + 1
+      assert(b.contains(newElem))
+      assert(b.size == expectedSize)
+      assert(b.multiplicity(newElem) == 1)
+    }
+
+    it should "support adding multiple elements with +=" in {
+      val b = bag
+      b.+=((newElem, 3))
+      val expectedSize = bag.size + 3
+      assert(b.contains(newElem))
+      assert(b.size == expectedSize)
+      assert(b.multiplicity(newElem) == 3)
+    }
+
+    it should "support changing the multiplicity with setMultiplicity" in {
+      val b = bag
+      val elem = b.head
+      b.setMultiplicity(elem, 3)
+      assert(b.multiplicity(elem) == 3)
+      b.setMultiplicity(elem, 5)
+      assert(b.multiplicity(elem) == 5)
+    }
+
+    it should "support changing the multiplicity with update" in {
+      val b = bag
+      val elem = b.head
+      b.update(elem, 3)
+      assert(b.multiplicity(elem) == 3)
+      b.update(elem, 5)
+      assert(b.multiplicity(elem) == 5)
     }
   }
 }

--- a/src/test/scala/scala/collection/scalatest/mutable/MutableIntBagTest.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableIntBagTest.scala
@@ -8,5 +8,7 @@ trait MutableIntBagTest extends IntBagTest with MutableBagBehaviours {
 
   override def bagWithOneOneTwoThreeThreeThree = emptyBag + (1 -> 2) + (2 -> 1) + (3 -> 3)
 
-  it should behave like mutableBagBehaviour[Int](bagWithOneOneTwoThreeThreeThree)
+  def elem: Int = 4
+
+  it should behave like mutableBagBehaviour[Int](bagWithOneOneTwoThreeThreeThree, elem)
 }

--- a/src/test/scala/scala/collection/scalatest/mutable/MutableIntBagTest.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableIntBagTest.scala
@@ -8,7 +8,8 @@ trait MutableIntBagTest extends IntBagTest with MutableBagBehaviours {
 
   override def bagWithOneOneTwoThreeThreeThree = emptyBag + (1 -> 2) + (2 -> 1) + (3 -> 3)
 
-  def elem: Int = 4
+  def elem = 4
 
-  it should behave like mutableBagBehaviour[Int](bagWithOneOneTwoThreeThreeThree, elem)
+  "A mutable non-empty Bag of Integers" should behave like nonEmptyMutableBagBehaviour[Int](bagWithOneOneTwoThreeThreeThree, elem)
+  "A mutable empty Bag of Integers" should behave like mutableBagBehaviour[Int](emptyBag, elem)
 }

--- a/src/test/scala/scala/collection/scalatest/mutable/MutableStringBagTest.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableStringBagTest.scala
@@ -6,13 +6,10 @@ trait MutableStringBagTest extends StringBagTest with MutableBagBehaviours {
 
   override def emptyBag: collection.mutable.Bag[String]
 
-  override def bagWithCatCatDogMouseMouseMouse =
-    emptyBag + ("Cat" -> 2) + ("Dog" -> 1) + ("Mouse" -> 3)
+  override def bagWithCatCatDogMouseMouseMouse = emptyBag + ("Cat" -> 2) + ("Dog" -> 1) + ("Mouse" -> 3)
 
   def elem = "Horse"
 
-  it should behave like mutableBagBehaviour[String](bagWithCatCatDogMouseMouseMouse, elem)
-
-
-
+  "A mutable non-empty Bag of Strings" should behave like nonEmptyMutableBagBehaviour[String](bagWithCatCatDogMouseMouseMouse, elem)
+  "A mutable empty Bag of Strings" should behave like mutableBagBehaviour[String](emptyBag, elem)
 }

--- a/src/test/scala/scala/collection/scalatest/mutable/MutableStringBagTest.scala
+++ b/src/test/scala/scala/collection/scalatest/mutable/MutableStringBagTest.scala
@@ -9,6 +9,10 @@ trait MutableStringBagTest extends StringBagTest with MutableBagBehaviours {
   override def bagWithCatCatDogMouseMouseMouse =
     emptyBag + ("Cat" -> 2) + ("Dog" -> 1) + ("Mouse" -> 3)
 
-  it should behave like mutableBagBehaviour[String](bagWithCatCatDogMouseMouseMouse)
+  def elem = "Horse"
+
+  it should behave like mutableBagBehaviour[String](bagWithCatCatDogMouseMouseMouse, elem)
+
+
 
 }


### PR DESCRIPTION
This adds some tests for the remaining mutation operations. I'm not sure whether it makes sense to test all public methods, as some of them simply forward calls to each other.